### PR TITLE
Fix commit/rollback structure in SqlFilesRepository.save()

### DIFF
--- a/manager/downloads_infrastructure/downloads_infrastructure/repositories/files.py
+++ b/manager/downloads_infrastructure/downloads_infrastructure/repositories/files.py
@@ -1,4 +1,3 @@
-import sqlite3
 from typing import Optional
 
 from sqlify import Sqlite3Sqlify
@@ -24,24 +23,21 @@ class SqlFilesRepository(FilesRepository):
         return File.from_dict(obj)
 
     def save(self, file: File) -> None:
-        # TODO: fix this commit rollback structure
-        self._database.commit()
-        try:
-            self._database.insert(
-                table="downloads",
-                data=File.to_dict(file),
-            )
+        existing = self.get(file.hash)
 
-            self._database.commit()
-        except sqlite3.IntegrityError:
-            self._database.rollback()
+        if existing:
             self._database.update(
                 table="downloads",
                 where=("hash = :hash", dict(hash=file.hash)),
                 data=File.to_dict(file),
             )
+        else:
+            self._database.insert(
+                table="downloads",
+                data=File.to_dict(file),
+            )
 
-            self._database.commit()
+        self._database.commit()
 
     def retry_all(self) -> None:
         self._database.update(


### PR DESCRIPTION
## Summary

- Resolves the `TODO: fix this commit rollback structure` in `SqlFilesRepository.save()`
- Replaces the try/except `IntegrityError` pattern with a check-then-insert/update approach
- Removes the premature `commit()` call that was a workaround to protect against rollback undoing unrelated pending operations
- Removes the unused `sqlite3` import

## Details

The previous implementation had a problematic pattern:
1. Called `commit()` before the insert to protect pending work from a potential rollback
2. Attempted an insert inside a try block
3. On `IntegrityError`, rolled back and performed an update instead

This was fragile because the initial `commit()` could commit unrelated pending operations prematurely, and the `rollback()` on failure could still affect other state.

The new approach simply checks if a record with the same hash already exists using the `get()` method, then either updates or inserts accordingly. This is cleaner, requires only a single `commit()` at the end, and eliminates the need for exception-based control flow.

## Test plan

- [x] Verified the logic preserves the same upsert behavior (insert if new, update if existing)
- [ ] Manual testing with the download manager to confirm save operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)