### PR TITLE
Fix headers dict mutation bug in download_file()

### DIFF
--- a/manager/downloads_infrastructure/downloads_infrastructure/repositories/download.py
+++ b/manager/downloads_infrastructure/downloads_infrastructure/repositories/download.py
@@ -25,7 +25,7 @@ class SmartDLDownloadRepository(DownloadRepository):
             self.logger.warning(f"File {name} already exists in path {path}")
 
         try:
-            _tmp_headers = headers
+            _tmp_headers = dict(headers) if headers else {}
             _tmp_headers.setdefault("User-Agent", "DownloadManager 1.0")
 
             obj = SmartDL(


### PR DESCRIPTION
## Summary

- **download.py**: `_tmp_headers = headers` creates an alias, not a copy. Calling `setdefault()` on it mutates the caller's original headers dict, causing a side-effect bug. Additionally, if `headers` is `None` (which the type signature allows via `Optional[Dict]`), this crashes with `AttributeError`. Fixed by creating a proper copy with `dict(headers) if headers else {}`.

**Note:** The original PR also included a `files.py` fix for the premature `commit()` call, but that was already addressed by PR #7 and merged. This PR now contains only the headers mutation fix.

## Changes

| File | Change |
|------|--------|
| `repositories/download.py` | Copy headers dict before mutation, handle `None` |

## Why this is beneficial

- Prevents silent data corruption from dict mutation side effects
- Prevents `AttributeError` crash when headers is `None`
- No breaking changes — behavior is preserved, only side effects are removed