### PR TITLE
Fix: set completion_date instead of creation_date on download success

### DIFF
--- a/manager/downloads/downloads/application/use_cases/task_download_file.py
+++ b/manager/downloads/downloads/application/use_cases/task_download_file.py
@@ -35,7 +35,7 @@ class TaskDownloadFile:
             updated_file = file.copy_with(
                 completed=True,
                 failed=FailTypes.NoError,
-                creation_date=datetime.now(),
+                completion_date=datetime.now(),
             )
 
             self.logger.info("Download Finished")


### PR DESCRIPTION
## Summary

- Fixes a bug in `TaskDownloadFile.execute()` where a successful download sets `creation_date=datetime.now()` instead of `completion_date=datetime.now()`
- This overwrites the original creation timestamp and leaves `completion_date` as `None` for every completed file

## Details

In `manager/downloads/downloads/application/use_cases/task_download_file.py`, when a download completes successfully, the code calls:

```python
updated_file = file.copy_with(
    completed=True,
    failed=FailTypes.NoError,
    creation_date=datetime.now(),  # Bug: should be completion_date
)
```

The `File` entity has both `creation_date` (set when the download is first scheduled in `FileDownload.execute()`) and `completion_date` (which should be set when the download finishes). This one-word fix ensures `completion_date` is set correctly and `creation_date` is preserved.

## Change

| File | Change |
|------|--------|
| `manager/downloads/.../use_cases/task_download_file.py` | `creation_date` → `completion_date` on line 38 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)